### PR TITLE
feat: add resolution independence

### DIFF
--- a/src/Game.cpp
+++ b/src/Game.cpp
@@ -2,10 +2,12 @@
 
 // Constructor / Destructor
 
-Game::Game(){
+Game::Game()
+{
 
     // Initialising Window and config
-    this->window = std::make_shared<sf::RenderWindow>(sf::VideoMode(WINDOW_WIDTH, WINDOW_HEIGHT), "Platform-Shooter", sf::Style::None);
+    sf::VideoMode desktop = sf::VideoMode::getDesktopMode();
+    this->window = std::make_shared<sf::RenderWindow>(desktop, "Platform-Shooter", sf::Style::Fullscreen);
     // this->window->setFramerateLimit(120);
 
     // Pushing states to the stack
@@ -13,10 +15,12 @@ Game::Game(){
     this->states.push(std::make_unique<MainMenuState>(this->window));
 }
 
-Game::~Game(){
+Game::~Game()
+{
 
     // removing all states from stack
-    while(!this->states.empty()){
+    while (!this->states.empty())
+    {
         this->states.pop();
     }
 }
@@ -36,45 +40,56 @@ void Game::updateDT()
 
 // Main Functions
 
-void Game::update(){ 
+void Game::update()
+{
 
     // updateDT() needs to run before anything else, to ensure frametime is accurate
     this->updateDT();
 
     // updating the state on the top of the stack, if the stack is not empty
-    if(!this->states.empty()){
+    if (!this->states.empty())
+    {
         this->states.top()->handleEvents(this->window, this->event);
         this->states.top()->update(this->dt);
 
-        if (this->states.top()->forceExit()){
+        if (this->states.top()->forceExit())
+        {
             this->endApp();
         }
 
         // removes state from stack when moving to new state in the game
-        if (this->states.top()->getQuit()){
+        if (this->states.top()->getQuit())
+        {
             this->states.top()->endState(); // anything necessary before deleting state (e.g: saving progress)
             this->states.pop();
         }
     }
 
     // Stack empty, Game end, closing program
-    else { this->endApp(); }
+    else
+    {
+        this->endApp();
+    }
 }
 
-void Game::render(){
+void Game::render()
+{
     // clear screen, set background to grey if no other background texture is present
     this->window->clear(sf::Color(180, 180, 180));
 
     // rendering the state on the top of the stack, if the stack is not empty
-    if(!this->states.empty()){
+    if (!this->states.empty())
+    {
         this->states.top()->render(this->window);
     }
-    
+
     this->window->display();
 }
 
-void Game::run(){
-    while ( this->window->isOpen() ){
+void Game::run()
+{
+    while (this->window->isOpen())
+    {
         this->update();
         this->render();
     }

--- a/src/Game.h
+++ b/src/Game.h
@@ -3,10 +3,10 @@
 #include "states/GameState.h"
 #include "states/MainMenuState.h"
 
-class Game{
+class Game
+{
 
 private:
-
     // Variables
     std::shared_ptr<sf::RenderWindow> window;
     sf::Event event;
@@ -18,7 +18,6 @@ private:
     std::stack<std::unique_ptr<State>> states;
 
 public:
-
     // C-tor / D-tor
     Game();
     virtual ~Game();

--- a/src/entities/Bullet.cpp
+++ b/src/entities/Bullet.cpp
@@ -3,9 +3,9 @@
 Bullet::Bullet(sf::Vector2f startPosition, int direction)
 {
     // Initialising bullet
-    this->size = {20.0f, 8.0f};
+    this->size = {20.0f * screenScale.x, 8.0f * screenScale.y};
     this->position = startPosition;
-    this->speed = 700.0f;
+    this->speed = 700.0f * screenScale.x;
     this->direction = direction;
 
     bullet.setFillColor(sf::Color::White);
@@ -13,7 +13,7 @@ Bullet::Bullet(sf::Vector2f startPosition, int direction)
     bullet.setSize(size);
 }
 
-Bullet::~Bullet(){}
+Bullet::~Bullet() {}
 
 sf::RectangleShape &Bullet::getShape()
 {

--- a/src/entities/Bullet.h
+++ b/src/entities/Bullet.h
@@ -1,10 +1,15 @@
 #pragma once
 #include "../includes.h"
 
-class Bullet 
+class Bullet
 {
 private:
-    
+    // Window variables
+    sf::VideoMode desktop = sf::VideoMode::getDesktopMode(); // desktop width and height
+    sf::Vector2f screenScale = {
+        static_cast<float>(desktop.width) / BASE_WIDTH,
+        static_cast<float>(desktop.height) / BASE_HEIGHT}; // scale of screen compared to base values (1920x1080)
+
     // Bullet variables
     sf::RectangleShape bullet;
 
@@ -14,7 +19,6 @@ private:
     int direction; // direction bullet was shot in. 1 - right, -1 - left
 
 public:
-    
     // C-tor / D-tor
     Bullet(sf::Vector2f startPosition, int direction);
     virtual ~Bullet();
@@ -23,9 +27,8 @@ public:
     sf::RectangleShape &getShape();
 
     void setPosition(sf::Vector2f position);
-	sf::Vector2f getPosition();
+    sf::Vector2f getPosition();
     sf::Vector2f getSize();
     int getDirection();
     float getSpeed();
-
 };

--- a/src/entities/Player.cpp
+++ b/src/entities/Player.cpp
@@ -7,16 +7,16 @@ Player::Player(sf::Vector2f position)
     // Initialising player variables
     this->spawnPosition = position;
     this->playerPosition = this->spawnPosition;
-    this->playerSize = sf::Vector2f(50.0f, 100.0f);
+    this->playerSize = sf::Vector2f(50.0f * screenScale.x, 100.0f * screenScale.y);
     this->lives = 3;
-    this->playerWalkSpeed = 250.0f;
+    this->playerWalkSpeed = 250.0f * screenScale.x;
     this->isJump = false;
     this->fall = false;
     this->fallingMomentum = 0.0f;
-    this->fallingAcceleration = 800.0f;
-    this->startJumpingMomentum = 400.0f; // allows jumpingMomentum to be reset to this value after each jump
+    this->fallingAcceleration = 800.0f * screenScale.y;
+    this->startJumpingMomentum = 400.0f * screenScale.y; // allows jumpingMomentum to be reset to this value after each jump
     this->jumpingMomentum = this->startJumpingMomentum;
-    this->jumpingAcceleration = -1000.0f;
+    this->jumpingAcceleration = -1000.0f * screenScale.y;
     this->direction = 1;
 
     // Initialing player shape
@@ -85,11 +85,11 @@ void Player::setDirection(int direction)
 
 bool Player::isGrounded(sf::RectangleShape platform)
 {
-    if (this->playerPosition.y + this->playerSize.y == platform.getPosition().y 
-    && (this->playerPosition.x + this->playerSize.x) > platform.getPosition().x 
-    && this->playerPosition.x < platform.getPosition().x + platform.getSize().x ){ // Playing is touching the platform, return true. else return false
+    if (this->playerPosition.y + this->playerSize.y == platform.getPosition().y && (this->playerPosition.x + this->playerSize.x) > platform.getPosition().x && this->playerPosition.x < platform.getPosition().x + platform.getSize().x)
+    { // Playing is touching the platform, return true. else return false
         return true;
-    } return false;
+    }
+    return false;
 }
 
 bool Player::isJumping()

--- a/src/entities/Player.h
+++ b/src/entities/Player.h
@@ -1,9 +1,15 @@
 #pragma once
 #include "../includes.h"
 
-class Player {
+class Player
+{
 
 private:
+    // Window variables
+    sf::VideoMode desktop = sf::VideoMode::getDesktopMode(); // desktop width and height
+    sf::Vector2f screenScale = {
+        static_cast<float>(desktop.width) / BASE_WIDTH,
+        static_cast<float>(desktop.height) / BASE_HEIGHT}; // scale of screen compared to base values (1920x1080)
 
     // Player shape
     sf::RectangleShape playerShape;
@@ -23,9 +29,7 @@ private:
     float jumpingAcceleration;
     int direction; // 1 - facing right, 2 - facing left
 
-
 public:
-
     // C-tor / D-tor
     Player(sf::Vector2f spawnPosition = {0.0f, 0.0f});
     virtual ~Player();

--- a/src/includes.h
+++ b/src/includes.h
@@ -8,5 +8,6 @@
 #include <vector>
 #include <memory>
 
-#define WINDOW_WIDTH 1600
-#define WINDOW_HEIGHT 900
+// base window height for calculating resolution independence
+#define BASE_WIDTH 1920
+#define BASE_HEIGHT 1080

--- a/src/level/Background.h
+++ b/src/level/Background.h
@@ -1,11 +1,13 @@
 #pragma once
 #include "../includes.h"
 
-class Background {
+class Background
+{
 
 private:
-
     // Variables
+    sf::VideoMode desktop = sf::VideoMode::getDesktopMode(); // desktop width and height
+
     sf::RectangleShape gameBackgroundShape;
     sf::Texture gameBackgroundTexture;
 
@@ -13,10 +15,9 @@ private:
     sf::Texture menuBackgroundTexture;
 
 public:
-
     // C-tor / D-tor
-    Background(){}
-    virtual ~Background(){}
+    Background() {}
+    virtual ~Background() {}
 
     // Other functions
     sf::RectangleShape getGameBackgroundShape() { return this->gameBackgroundShape; }
@@ -25,7 +26,7 @@ public:
     void initGameBackground()
     {
         gameBackgroundShape.setPosition({0, 0});
-        gameBackgroundShape.setSize({WINDOW_WIDTH, WINDOW_HEIGHT});
+        gameBackgroundShape.setSize({static_cast<float>(desktop.width), static_cast<float>(desktop.height)});
         gameBackgroundTexture.loadFromFile("assets/game-background.png");
         gameBackgroundShape.setTexture(&gameBackgroundTexture);
     }
@@ -33,10 +34,8 @@ public:
     void initMenuBackground()
     {
         menuBackgroundShape.setPosition({0, 0});
-        menuBackgroundShape.setSize({WINDOW_WIDTH, WINDOW_HEIGHT});
+        menuBackgroundShape.setSize({static_cast<float>(desktop.width), static_cast<float>(desktop.height)});
         menuBackgroundTexture.loadFromFile("assets/menu-background.png");
         menuBackgroundShape.setTexture(&menuBackgroundTexture);
-
     }
-
 };

--- a/src/level/Platform.cpp
+++ b/src/level/Platform.cpp
@@ -5,7 +5,7 @@
 Platform::Platform()
 {
     // Initialising platform variables
-    this->platformSize = {960 * screenScale, 105 * screenScale};
+    this->platformSize = {960 * screenScale.x, 105 * screenScale.y};
     this->platformPosition = {((desktop.width - platformSize.x) / 2), desktop.height / 1.5f};
 
     // Initialising platform shape object

--- a/src/level/Platform.cpp
+++ b/src/level/Platform.cpp
@@ -6,7 +6,7 @@ Platform::Platform()
 {
     // Initialising platform variables
     this->platformSize = {960, 105};
-    this->platformPosition = {((WINDOW_WIDTH - platformSize.x) / 2), WINDOW_HEIGHT / 1.5};
+    this->platformPosition = {((desktop.width - platformSize.x) / 2), desktop.height / 1.5f};
 
     // Initialising platform shape object
     platformShape.setPosition(platformPosition);
@@ -15,7 +15,6 @@ Platform::Platform()
     // Initialising texture
     platformTexture.loadFromFile("assets/platform.png");
     platformShape.setTexture(&platformTexture);
-
 }
 
 Platform::~Platform()

--- a/src/level/Platform.cpp
+++ b/src/level/Platform.cpp
@@ -5,7 +5,7 @@
 Platform::Platform()
 {
     // Initialising platform variables
-    this->platformSize = {960, 105};
+    this->platformSize = {960 * screenScale, 105 * screenScale};
     this->platformPosition = {((desktop.width - platformSize.x) / 2), desktop.height / 1.5f};
 
     // Initialising platform shape object

--- a/src/level/Platform.h
+++ b/src/level/Platform.h
@@ -9,7 +9,9 @@ private:
     sf::RectangleShape platformShape;
     sf::Texture platformTexture;
     sf::VideoMode desktop = sf::VideoMode::getDesktopMode(); // desktop width and height
-    float screenScale = static_cast<float>(desktop.width) / BASE_WIDTH;
+    sf::Vector2f screenScale = {
+        static_cast<float>(desktop.width) / BASE_WIDTH,
+        static_cast<float>(desktop.height) / BASE_HEIGHT}; // scale of screen compared to base values (1920x1080)
 
     // Platform variables
     sf::Vector2f platformPosition;

--- a/src/level/Platform.h
+++ b/src/level/Platform.h
@@ -9,6 +9,7 @@ private:
     sf::RectangleShape platformShape;
     sf::Texture platformTexture;
     sf::VideoMode desktop = sf::VideoMode::getDesktopMode(); // desktop width and height
+    float screenScale = static_cast<float>(desktop.width) / BASE_WIDTH;
 
     // Platform variables
     sf::Vector2f platformPosition;

--- a/src/level/Platform.h
+++ b/src/level/Platform.h
@@ -1,20 +1,20 @@
 #pragma once
 #include "../includes.h"
 
-class Platform{
+class Platform
+{
 
 private:
-
     // Platform shape + texture
     sf::RectangleShape platformShape;
     sf::Texture platformTexture;
+    sf::VideoMode desktop = sf::VideoMode::getDesktopMode(); // desktop width and height
 
     // Platform variables
     sf::Vector2f platformPosition;
     sf::Vector2f platformSize;
 
 public:
-
     // C-tor / D-tor
     Platform();
     virtual ~Platform();

--- a/src/states/GameState.cpp
+++ b/src/states/GameState.cpp
@@ -5,7 +5,7 @@
 GameState::GameState(std::shared_ptr<sf::RenderWindow> &window) : State(window)
 {
     this->background.initGameBackground();
-    this->player = Player(sf::Vector2f(desktop.width / 2, desktop.height / 2));
+    this->player = Player(sf::Vector2f(static_cast<float>(desktop.width) / 2, static_cast<float>(desktop.height) / 2));
 }
 
 GameState::~GameState()

--- a/src/states/GameState.h
+++ b/src/states/GameState.h
@@ -5,16 +5,17 @@
 #include "../level/Platform.h"
 #include "../level/Background.h"
 
-class GameState : public State{
+class GameState : public State
+{
 private:
-
     // Class variables
     bool quit = false;
     sf::Event event;
-    bool isExit = false; // if set to true, game and window will force close
+    bool isExit = false;                                     // if set to true, game and window will force close
+    sf::VideoMode desktop = sf::VideoMode::getDesktopMode(); // desktop width and height
 
     // Initialising objects from other entities/level objects
-    Player player = Player(sf::Vector2f(WINDOW_WIDTH/2, WINDOW_HEIGHT/2));
+    Player player;
     Platform platform;
     Background background;
 
@@ -22,20 +23,19 @@ private:
     bool hasShot = false; // prevents player for holding Comma to spray bullets
 
 public:
-
     // C-tor / D-tor
     GameState(std::shared_ptr<sf::RenderWindow> &window);
     virtual ~GameState();
 
-    bool getQuit(); // Checks if state needs to be removed
+    bool getQuit();  // Checks if state needs to be removed
     void endState(); // Performs all necessary actions when state is removed
     bool forceExit();
 
     // Main Functions
     void handleEvents(std::shared_ptr<sf::RenderWindow> &window, sf::Event event);
-    void updateCollisions(const float& dt);
-    void updateKeybinds(const float& dt);
+    void updateCollisions(const float &dt);
+    void updateKeybinds(const float &dt);
     void updateEndingCheck();
-    void update(const float& dt);
+    void update(const float &dt);
     void render(std::shared_ptr<sf::RenderWindow> &window);
 };

--- a/src/states/MainMenuState.cpp
+++ b/src/states/MainMenuState.cpp
@@ -3,28 +3,46 @@
 // Private functions
 void MainMenuState::checkMenuClick(sf::Event::MouseButtonEvent mouse)
 {
-    sf::Vector2f mousePosition = {(float) mouse.x, (float) mouse.y};
+    sf::Vector2f mousePosition = {(float)mouse.x, (float)mouse.y};
 
-    if (menuButton_Play.getGlobalBounds().contains(mousePosition)){ this->isPlay = true; }
-    else if (menuButton_Settings.getGlobalBounds().contains(mousePosition)){ this->isSettings = true; }
-    else if (menuButton_Exit.getGlobalBounds().contains(mousePosition)){ this->isExit = true; }
+    if (menuButton_Play.getGlobalBounds().contains(mousePosition))
+    {
+        this->isPlay = true;
+    }
+    else if (menuButton_Settings.getGlobalBounds().contains(mousePosition))
+    {
+        this->isSettings = true;
+    }
+    else if (menuButton_Exit.getGlobalBounds().contains(mousePosition))
+    {
+        this->isExit = true;
+    }
 }
 
 void MainMenuState::checkMousePosition(sf::Event::MouseMoveEvent mouse)
 {
     // Getting mouse current X and Y position
-    sf::Vector2f mousePosition = { (float) mouse.x, (float) mouse.y };
+    sf::Vector2f mousePosition = {(float)mouse.x, (float)mouse.y};
 
     // Changes button textures to hover when mouse is touching them
-    if (menuButton_Play.getGlobalBounds().contains(mousePosition)){ menuButton_Play.setTexture(&playButtonTexture_hover); }
-    else if (menuButton_Settings.getGlobalBounds().contains(mousePosition)){ menuButton_Settings.setTexture(&settingsButtonTexture_hover); }
-    else if (menuButton_Exit.getGlobalBounds().contains(mousePosition)){ menuButton_Exit.setTexture(&exitButtonTexture_hover); }
+    if (menuButton_Play.getGlobalBounds().contains(mousePosition))
+    {
+        menuButton_Play.setTexture(&playButtonTexture_hover);
+    }
+    else if (menuButton_Settings.getGlobalBounds().contains(mousePosition))
+    {
+        menuButton_Settings.setTexture(&settingsButtonTexture_hover);
+    }
+    else if (menuButton_Exit.getGlobalBounds().contains(mousePosition))
+    {
+        menuButton_Exit.setTexture(&exitButtonTexture_hover);
+    }
 
     else
     {
         // Resets all menu buttons to non-hover textures
         menuButton_Play.setTexture(&playButtonTexture);
-        menuButton_Settings.setTexture(&settingsButtonTexture); 
+        menuButton_Settings.setTexture(&settingsButtonTexture);
         menuButton_Exit.setTexture(&exitButtonTexture);
     }
 }
@@ -32,24 +50,24 @@ void MainMenuState::checkMousePosition(sf::Event::MouseMoveEvent mouse)
 void MainMenuState::initMenuButtons()
 {
     // Initialising values for central menu buttons (Play, settings, exit)
-    centralMenuButtonsSize = {WINDOW_WIDTH / 6, WINDOW_HEIGHT / 7.8f};
-    centralMenuButtonsX = (WINDOW_WIDTH / 2) - (centralMenuButtonsSize.x / 2);
+    centralMenuButtonsSize = {desktop.width / 6.0f, desktop.height / 7.8f};
+    centralMenuButtonsX = (desktop.width / 2) - (centralMenuButtonsSize.x / 2);
 
     // Initialising button rectangle shapes
     menuButton_Play.setSize(centralMenuButtonsSize);
-    menuButton_Play.setPosition({centralMenuButtonsX, WINDOW_HEIGHT * 0.42f});
+    menuButton_Play.setPosition({centralMenuButtonsX, desktop.height * 0.42f});
     playButtonTexture.loadFromFile("assets/main-menu-buttons/play.png");
     playButtonTexture_hover.loadFromFile("assets/main-menu-buttons/play-hover.png");
     menuButton_Play.setTexture(&playButtonTexture);
 
     menuButton_Settings.setSize(centralMenuButtonsSize);
-    menuButton_Settings.setPosition({centralMenuButtonsX, WINDOW_HEIGHT * 0.56f});
+    menuButton_Settings.setPosition({centralMenuButtonsX, desktop.height * 0.56f});
     settingsButtonTexture.loadFromFile("assets/main-menu-buttons/settings.png");
     settingsButtonTexture_hover.loadFromFile("assets/main-menu-buttons/settings-hover.png");
     menuButton_Settings.setTexture(&settingsButtonTexture);
 
     menuButton_Exit.setSize(centralMenuButtonsSize);
-    menuButton_Exit.setPosition({centralMenuButtonsX, WINDOW_HEIGHT * 0.7f});
+    menuButton_Exit.setPosition({centralMenuButtonsX, desktop.height * 0.7f});
     exitButtonTexture.loadFromFile("assets/main-menu-buttons/exit.png");
     exitButtonTexture_hover.loadFromFile("assets/main-menu-buttons/exit-hover.png");
     menuButton_Exit.setTexture(&exitButtonTexture);
@@ -90,19 +108,24 @@ bool MainMenuState::forceExit()
 
 void MainMenuState::handleEvents(std::shared_ptr<sf::RenderWindow> &window, sf::Event event)
 {
-    while(window->pollEvent(event)){
-        switch(event.type){
-            case sf::Event::Closed:
-                window->close();
-                break;
+    while (window->pollEvent(event))
+    {
+        switch (event.type)
+        {
+        case sf::Event::Closed:
+            window->close();
+            break;
 
-            case sf::Event::MouseButtonPressed:
-                if (event.key.code == sf::Mouse::Left){ this->checkMenuClick(event.mouseButton); }
-                break;
+        case sf::Event::MouseButtonPressed:
+            if (event.key.code == sf::Mouse::Left)
+            {
+                this->checkMenuClick(event.mouseButton);
+            }
+            break;
 
-            case sf::Event::MouseMoved:
-                this->checkMousePosition(event.mouseMove);
-                break;
+        case sf::Event::MouseMoved:
+            this->checkMousePosition(event.mouseMove);
+            break;
         }
     }
 }
@@ -111,8 +134,10 @@ void MainMenuState::updateKeybinds(const float &dt)
 {
     // Check for keypresses
 
-    if (isSettings){
-        if (sf::Keyboard::isKeyPressed(sf::Keyboard::Escape)){
+    if (isSettings)
+    {
+        if (sf::Keyboard::isKeyPressed(sf::Keyboard::Escape))
+        {
             this->isSettings = false;
         }
     }
@@ -123,7 +148,10 @@ void MainMenuState::updateEndingCheck()
     /* Checks for ways the state could end. then set this->quit to true */
 
     // If players clicks Play, ends menu state to load game
-    if (isPlay) { this->quit = true; }
+    if (isPlay)
+    {
+        this->quit = true;
+    }
 }
 
 // Main Functions
@@ -140,15 +168,16 @@ void MainMenuState::render(std::shared_ptr<sf::RenderWindow> &window)
     window->draw(this->background.getMenuBackgroundShape());
 
     // Main Menu
-    if (!this->isSettings){
+    if (!this->isSettings)
+    {
         // Drawing main menu buttons
         window->draw(menuButton_Play);
         window->draw(menuButton_Settings);
         window->draw(menuButton_Exit);
-    } 
-    
+    }
+
     // Settings Menu
-    else if (this->isSettings){
-        
+    else if (this->isSettings)
+    {
     }
 }

--- a/src/states/MainMenuState.h
+++ b/src/states/MainMenuState.h
@@ -2,12 +2,13 @@
 #include "../State.h"
 #include "../level/Background.h"
 
-class MainMenuState : public State{
+class MainMenuState : public State
+{
 private:
-
     // Class variables
     bool quit = false;
     sf::Event event;
+    sf::VideoMode desktop = sf::VideoMode::getDesktopMode(); // desktop width and height
 
     // Menu background
     Background background;
@@ -38,19 +39,18 @@ private:
     void checkMousePosition(sf::Event::MouseMoveEvent mouse);
 
 public:
-
     // C-tor / D-tor
     MainMenuState(std::shared_ptr<sf::RenderWindow> &window);
     virtual ~MainMenuState();
 
-    bool getQuit(); // Checks if state needs to be removed
-    void endState(); // Performs all necessary actions when state is removed
+    bool getQuit();   // Checks if state needs to be removed
+    void endState();  // Performs all necessary actions when state is removed
     bool forceExit(); // Check if exit button is pressed and game should be closed
 
     // Main Functions
     void handleEvents(std::shared_ptr<sf::RenderWindow> &window, sf::Event event);
-    void updateKeybinds(const float& dt);
+    void updateKeybinds(const float &dt);
     void updateEndingCheck();
-    void update(const float& dt);
+    void update(const float &dt);
     void render(std::shared_ptr<sf::RenderWindow> &window);
 };


### PR DESCRIPTION
Add scaling of size and speed for all objects and entities in the game. Allows game to look and feel the same on all resolutions.

## Implementation
Captured the desktop size using `sf::VideoMode::getDesktopMode();` (assigning it to `desktop`)

Then added some base values for the width and height, to calculate the scale of the window from:
```cpp
// includes.h
#define BASE_WIDTH 1920
#define BASE_HEIGHT 1080
```

After, I stored these scale values in a vector, to use respectively for scaling on the `x` /  `y` axis:
```cpp
sf::Vector2f screenScale = {
    static_cast<float>(desktop.width) / BASE_WIDTH,
    static_cast<float>(desktop.height) / BASE_HEIGHT}; // scale of screen compared to base values (1920x1080)
```

Applying the scaling:
```cpp
this->playerSize = sf::Vector2f(50.0f * screenScale.x, 100.0f * screenScale.y);
this->playerWalkSpeed = 250.0f * screenScale.x;
```